### PR TITLE
Fix issue with new guest details section

### DIFF
--- a/Model/Form/Modifier/AddHousenumberFieldValidation.php
+++ b/Model/Form/Modifier/AddHousenumberFieldValidation.php
@@ -5,6 +5,7 @@
 
 namespace Vendic\HyvaCheckoutGoogleAddressAutocomplete\Model\Form\Modifier;
 
+use Hyva\Checkout\Model\Form\EntityFormElementInterface;
 use Hyva\Checkout\Model\Form\EntityFormInterface;
 use Hyva\Checkout\Model\Form\EntityFormModifierInterface;
 
@@ -25,6 +26,10 @@ class AddHousenumberFieldValidation implements EntityFormModifierInterface
             'form:build',
             function (EntityFormInterface $form) {
                 $street = $form->getElement('street');
+
+                if (!$street instanceof EntityFormElementInterface) {
+                    return;
+                }
 
                 $relatives = $street->getRelatives();
 


### PR DESCRIPTION
The component was checking for a street field. For the new guest details section this isn't available. So for that reason an additional check has been added to skip further logic if there is no "street" field.