### PR TITLE
Add browser event to refresh JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ There is no disable/enable configuration. To disable the module, simply remove t
 - [ ] Autocomplete for adding a new address as a logged in user (see [#5](https://github.com/Vendic/hyva-checkout-google-address-autocomplete/issues/5))
 - [x] Works on the company field and street 0. To add additonal fields, check `\Vendic\HyvaCheckoutGoogleAddressAutocomplete\ViewModel\AutoCompleteSelectors`
 - [x] Housenumber validation to check if the housenumber contains digits. 
+- [x] Reload autocomplete JS by triggering a browser event named `re-init-google-autocomplete`. This can be useful when you are removing/adding fields dynamically.
 
 ## Customizations
 ### Field mapping

--- a/view/frontend/templates/checkout/google-autocomplete-js.phtml
+++ b/view/frontend/templates/checkout/google-autocomplete-js.phtml
@@ -44,6 +44,9 @@ if (!$apiKey) {
         // Re-init autocomplete when billing as shipping is toggled
         window.addEventListener('billing-as-shipping-toggled', () => { reInitAutocomplete()} );
 
+        // Allow for re-initialization of the Google Autocomplete functionality via external scripts
+        window.addEventListener('re-init-google-autocomplete', () => { reInitAutocomplete() });
+
         // Wait for Google Maps JS callback to add autocomplete to specified inputs
         document.addEventListener('google_maps_js_loaded', () => { addAutocompleteToInputs(); });
 


### PR DESCRIPTION
Reload autocomplete JS by triggering a browser event named `re-init-google-autocomplete`. This can be useful when you are removing/adding fields dynamically.