### PR TITLE
improvement: add function to join result-values & remove house-number-validation

### DIFF
--- a/ViewModel/FieldMapping.php
+++ b/ViewModel/FieldMapping.php
@@ -15,6 +15,6 @@ class FieldMapping implements ArgumentInterface
 
     public function get() : array
     {
-        return $this->fieldMapping;
+        return array_filter($this->fieldMapping);
     }
 }

--- a/ViewModel/FieldMapping.php
+++ b/ViewModel/FieldMapping.php
@@ -17,4 +17,18 @@ class FieldMapping implements ArgumentInterface
     {
         return array_filter($this->fieldMapping);
     }
+
+    /**
+     * returns the index of the house-number field, if it is enabled
+     */
+    public function getHouseNumberFieldIndex(): ?int
+    {
+        preg_match('/^street\.(\d+)$/', $this->get()['street_number'] ?? '', $matches);
+        $houseNumberFieldIndex = $matches[1] ?? null;
+        if (is_numeric($houseNumberFieldIndex)) {
+            return (int) $houseNumberFieldIndex;
+        }
+
+        return null;
+    }
 }

--- a/view/frontend/templates/checkout/google-autocomplete-js.phtml
+++ b/view/frontend/templates/checkout/google-autocomplete-js.phtml
@@ -100,9 +100,11 @@ if (!$apiKey) {
             });
 
             Object.keys(fieldMappings).forEach(key => {
-                const value = address[key];
+                const dataKeys = key.split('+');
+                const valueToSave = dataKeys.map((key) => address[key]).filter((v) => v);
+
                 const identifier = `address.${fieldMappings[key]}`;
-                component.set(identifier, value ?? "");
+                component.set(identifier,  valueToSave.join(' '));
             });
 
             component.save();

--- a/view/frontend/templates/checkout/housenumber-validation-rule.phtml
+++ b/view/frontend/templates/checkout/housenumber-validation-rule.phtml
@@ -4,13 +4,22 @@ declare(strict_types=1);
 
 use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
+use Hyva\Theme\Model\ViewModelRegistry;
 use Hyva\Theme\ViewModel\HyvaCsp;
+use Vendic\HyvaCheckoutGoogleAddressAutocomplete\ViewModel\FieldMapping;
 
 // phpcs:disable Generic.Files.LineLength
 
 /** @var Escaper $escaper */
 /** @var Template $block */
 /** @var HyvaCsp $hyvaCsp */
+/** @var ViewModelRegistry $viewModels */
+
+/** @var FieldMapping $fieldMapping */
+$fieldMapping = $viewModels->require(FieldMapping::class);
+if ($fieldMapping->getHouseNumberFieldIndex() === null) {
+    return;
+}
 
 ?>
 <script>


### PR DESCRIPTION
thank you for this great extension!

this pull request adds the function to join the result fields. 

In the most cases (for my customers) the street and the house-number needs to be in one field. 
the second street line is the field for information like "c/o" or a special house-number if the main-address is like a campus. 

So with this PR it is possible to have a configuration like this: (shortend)

```xml
<type name="Vendic\HyvaCheckoutGoogleAddressAutocomplete\ViewModel\FieldMapping">
        <arguments>
            <argument name="fieldMapping" xsi:type="array">
                <item name="route+street_number" xsi:type="string">street.0</item>
                <item name="subpremise" xsi:type="string">street.1</item>
            </argument>
        </arguments>
    </type>
```

This will lead into the german street/house-number format.
But you also can flip this both for the opposite order.

in addition: i added a array_filter to the mapping-model to make sure that it is possible to pass null-values to remove specific mappings:

```xml
<type name="Vendic\HyvaCheckoutGoogleAddressAutocomplete\ViewModel\FieldMapping">
      <arguments>
          <argument name="fieldMapping" xsi:type="array">
              <item name="street" xsi:type="null" />
          </argument>
      </arguments>
  </type>
```
