### PR TITLE
VEI-1652 require Hyva theme 1.3.12. Make module CSP compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Hyvä checkout compatibility module for vendic/magento2-google-address-autocomplete",
     "require": {
         "php": "~8.1",
+        "hyva-themes/magento2-default-theme": ">=1.3.12",
         "hyva-themes/magento2-hyva-checkout": "^1.1",
         "vendic/magento2-google-address-autocomplete": "^1.5"
     },

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="img-src">
+            <values>
+                <value id="g_static" type="host">https://maps.gstatic.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>

--- a/view/frontend/templates/checkout/google-autocomplete-js.phtml
+++ b/view/frontend/templates/checkout/google-autocomplete-js.phtml
@@ -1,12 +1,6 @@
-<?php declare(strict_types=1);
+<?php
 
-// phpcs:disable Generic.Files.LineLength
-
-/** @var Escaper $escaper */
-/** @var Template $block */
-/** @var ViewModelRegistry $viewModels */
-
-/** @var Settings $googleAutocompleteSettings */
+declare(strict_types=1);
 
 use Hyva\Theme\Model\ViewModelRegistry;
 use Magento\Framework\Escaper;
@@ -14,7 +8,16 @@ use Magento\Framework\View\Element\Template;
 use Vendic\GoogleAutocomplete\ViewModel\Settings;
 use Vendic\HyvaCheckoutGoogleAddressAutocomplete\ViewModel\AutoCompleteSelectors;
 use Vendic\HyvaCheckoutGoogleAddressAutocomplete\ViewModel\FieldMapping;
+use Hyva\Theme\ViewModel\HyvaCsp;
 
+// phpcs:disable Generic.Files.LineLength
+
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var ViewModelRegistry $viewModels */
+/** @var HyvaCsp $hyvaCsp */
+
+/** @var Settings $googleAutocompleteSettings */
 $googleAutocompleteSettings = $viewModels->require(Settings::class);
 $apiKey = $escaper->escapeHtml($googleAutocompleteSettings->getApiKey());
 
@@ -204,3 +207,4 @@ if (!$apiKey) {
         document.dispatchEvent(new Event('google_maps_js_loaded'));
     }
 </script>
+<?php $hyvaCsp->registerInlineScript() ?>

--- a/view/frontend/templates/checkout/housenumber-validation-rule.phtml
+++ b/view/frontend/templates/checkout/housenumber-validation-rule.phtml
@@ -1,9 +1,16 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
+
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\Template;
+use Hyva\Theme\ViewModel\HyvaCsp;
 
 // phpcs:disable Generic.Files.LineLength
 
-/** @var \Magento\Framework\Escaper $escaper */
-/** @var \Magento\Framework\View\Element\Template $block */
+/** @var Escaper $escaper */
+/** @var Template $block */
+/** @var HyvaCsp $hyvaCsp */
 
 ?>
 <script>
@@ -26,3 +33,4 @@
         }
     })()
 </script>
+<?php $hyvaCsp->registerInlineScript() ?>


### PR DESCRIPTION
## Description
Adaptation module's components for CSP on checkout

Updated Hyva version into theme composer, but alos need to update hyva-checkout to 1.3.0 version
What was done:
- Required Hyva theme >=1.3.12 version in composer
- Add "https://maps.gstatic.com" to CSP whitelist
- Adopted template/components which take part on checkout for CSP 

## Changelog
### Added
- [VEI-1652](https://app.clickup.com/t/6651913/VEI-1652) - make module CSP compatible on checkout